### PR TITLE
Add user to mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,9 +2603,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ juniper = "0.15.10"
 juniper_warp = "0.7.0"
 serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0.18"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1.23.1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 warp = { version = "0.3.2", default-features = false }
 sea-orm = { version = "^0", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "mock" ] }
 dotenvy = "0.15"

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -26,7 +26,6 @@ pub fn create_jwt(uid: &Uuid, role: &Role) -> Result<String, AuthorizationError>
 #[allow(dead_code)]
 pub fn authorize(role: &Role, token: &str) -> Result<Uuid, AuthorizationError> {
     let claims = get_claims_from_token(token)?;
-    claims.expired()?;
 
     let decoded_role = Role::from_str(&claims.role).unwrap_or(Role::Guest);
     match decoded_role.meets_requirements(role) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,8 @@ pub enum AuthorizationError {
     EncodingError(String),
     #[error("Token has expired")]
     TokenExpired,
+    #[error("Token missing")]
+    TokenMissing,
 }
 
 #[derive(Error, Debug)]

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -2,3 +2,4 @@ pub mod mutation;
 pub mod query;
 pub mod schema;
 pub mod subscription;
+pub mod user;

--- a/src/graphql/mutation/tests/user.rs
+++ b/src/graphql/mutation/tests/user.rs
@@ -1,11 +1,25 @@
 #[cfg(test)]
 mod test_auth_response {
-    use crate::graphql::mutation::user::AuthResponse;
+    use entity::sea_orm_active_enums::{Role, Status};
+
+    use crate::graphql::{mutation::user::AuthResponse, user::GQLUser};
 
     #[test]
     fn create_new_auth_response() {
-        let new = AuthResponse::new("token");
+        let user = GQLUser {
+            id: "id".to_string(),
+            email: "test@test.com".to_string(),
+            name: "test user".to_string(),
+            role: Role::Teacher,
+            status: Status::Offline,
+        };
+        let new = AuthResponse::new("token", user);
         assert_eq!(new.token, "token");
+        assert_eq!(new.user.id, "id");
+        assert_eq!(new.user.email, "test@test.com");
+        assert_eq!(new.user.name, "test user");
+        assert_eq!(new.user.role, Role::Teacher);
+        assert_eq!(new.user.status, Status::Offline);
     }
 }
 

--- a/src/graphql/mutation/user.rs
+++ b/src/graphql/mutation/user.rs
@@ -117,6 +117,7 @@ pub async fn signout(ctx: &Context, email: String) -> FieldResult<SignoutRespons
 
     match found {
         Some(found) => {
+            // `get_claims_From_token` is not happy
             let claims = get_claims_from_token(&ctx.token)?;
             if found.id != claims.sub {
                 return Err(UserError::UnableToComplete.into());

--- a/src/graphql/mutation/user.rs
+++ b/src/graphql/mutation/user.rs
@@ -97,6 +97,9 @@ pub async fn signin(ctx: &Context, email: String, password: String) -> FieldResu
     let found = User::find_one_by_email(&email, conn).await?;
     match found {
         Some(found) => {
+            if found.status != Status::Offline {
+                return Err(UserError::UnableToComplete.into());
+            }
             verify(&password, &found.password).map_err(|_| UserError::IncorrectEmailOrPassword)?;
 
             let mut found: user::ActiveModel = found.into();

--- a/src/graphql/query/tests/user.rs
+++ b/src/graphql/query/tests/user.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod test_user_response {
-    use crate::graphql::query::user::UserResponse;
     use entity::{
         sea_orm_active_enums::{Role, Status},
         user as user_entity,
     };
     use sea_orm::prelude::Uuid;
+
+    use crate::graphql::user::GQLUser;
 
     #[test]
     fn create_single_model() {
@@ -18,7 +19,7 @@ mod test_user_response {
             role: Role::Student,
             status: Status::Hidden,
         };
-        let got = UserResponse::single(&model);
+        let got = GQLUser::single(&model);
         assert_eq!(got.email, "test@test.com");
         assert_eq!(got.id, id.to_string());
         assert_eq!(got.name, "test user");
@@ -41,7 +42,7 @@ mod test_user_response {
                 status: statuses[i % 3].clone(),
             })
             .collect();
-        let responses = UserResponse::multiple(models);
+        let responses = GQLUser::multiple(models);
 
         for i in 0..9 {
             let got = &responses[i];

--- a/src/graphql/query/user.rs
+++ b/src/graphql/query/user.rs
@@ -1,76 +1,44 @@
-use juniper::{graphql_object, FieldResult, GraphQLObject};
+use juniper::{graphql_object, FieldResult};
 use sea_orm::prelude::Uuid;
 
 use super::QueryRoot;
-use crate::graphql::schema::Context;
-use entity::{
-    prelude::User,
-    sea_orm_active_enums::{Role, Status},
-    user,
-};
-
-#[derive(GraphQLObject, Debug)]
-pub struct UserResponse {
-    pub id: String,
-    pub name: String,
-    pub email: String,
-    pub role: Role,
-    pub status: Status,
-}
-
-impl UserResponse {
-    pub fn single(model: &user::Model) -> Self {
-        UserResponse {
-            id: model.id.to_string(),
-            name: model.name.to_string(),
-            email: model.email.to_string(),
-            role: model.role.to_owned(),
-            status: model.status.to_owned(),
-        }
-    }
-
-    pub fn multiple(models: Vec<user::Model>) -> Vec<Self> {
-        models
-            .into_iter()
-            .map(|model| UserResponse::single(&model))
-            .collect()
-    }
-}
+use crate::graphql::{schema::Context, user::GQLUser};
+use entity::prelude::User;
 
 #[graphql_object(Context = Context)]
 impl QueryRoot {
-    pub async fn user_by_email(ctx: &Context, email: String) -> FieldResult<Option<UserResponse>> {
+    pub async fn user_by_email(ctx: &Context, email: String) -> FieldResult<Option<GQLUser>> {
         find_user_by_email(ctx, email).await
     }
 
-    pub async fn user_by_id(ctx: &Context, id: String) -> FieldResult<Option<UserResponse>> {
+    pub async fn user_by_id(ctx: &Context, id: String) -> FieldResult<Option<GQLUser>> {
         find_user_by_id(ctx, id).await
     }
 
-    pub async fn users(ctx: &Context) -> FieldResult<Vec<UserResponse>> {
+    pub async fn users(ctx: &Context) -> FieldResult<Vec<GQLUser>> {
         get_users(ctx).await
     }
 }
 
-pub async fn find_user_by_email(ctx: &Context, email: String) -> FieldResult<Option<UserResponse>> {
+pub async fn find_user_by_email(ctx: &Context, email: String) -> FieldResult<Option<GQLUser>> {
     let conn = ctx.connection.as_ref();
     let found_user = User::find_one_by_email(&email, conn).await?;
 
-    let res = found_user.map(|model| UserResponse::single(&model));
+    let res = found_user.map(|model| GQLUser::single(&model));
     Ok(res)
 }
 
-pub async fn find_user_by_id(ctx: &Context, id: String) -> FieldResult<Option<UserResponse>> {
+pub async fn find_user_by_id(ctx: &Context, id: String) -> FieldResult<Option<GQLUser>> {
     let conn = ctx.connection.as_ref();
     let id = Uuid::parse_str(&id)?;
     let found_user = User::find_one_by_id(&id, conn).await?;
-    let res = found_user.map(|model| UserResponse::single(&model));
+    let res = found_user.map(|model| GQLUser::single(&model));
     Ok(res)
 }
 
-pub async fn get_users(ctx: &Context) -> FieldResult<Vec<UserResponse>> {
+pub async fn get_users(ctx: &Context) -> FieldResult<Vec<GQLUser>> {
     let conn = ctx.connection.as_ref();
     let users = User::find_all(conn).await?;
-    let res = UserResponse::multiple(users);
+    let res = GQLUser::multiple(users);
     Ok(res)
 }

--- a/src/graphql/user.rs
+++ b/src/graphql/user.rs
@@ -1,0 +1,44 @@
+use entity::{
+    sea_orm_active_enums::{Role, Status},
+    user,
+};
+use juniper::GraphQLObject;
+
+#[derive(GraphQLObject, Debug)]
+pub struct GQLUser {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+    pub role: Role,
+    pub status: Status,
+}
+
+impl GQLUser {
+    pub fn single(model: &user::Model) -> Self {
+        GQLUser {
+            id: model.id.to_string(),
+            name: model.name.to_string(),
+            email: model.email.to_string(),
+            role: model.role.to_owned(),
+            status: model.status.to_owned(),
+        }
+    }
+
+    pub fn multiple(models: Vec<user::Model>) -> Vec<Self> {
+        models
+            .into_iter()
+            .map(|model| GQLUser::single(&model))
+            .collect()
+    }
+    pub fn from_active_model(model: user::ActiveModel) -> Self {
+        let user = user::Model {
+            id: model.id.unwrap(),
+            email: model.email.unwrap(),
+            name: model.name.unwrap(),
+            status: model.status.unwrap(),
+            role: model.role.unwrap(),
+            password: model.password.unwrap(),
+        };
+        GQLUser::single(&user)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
-use std::env;
+use std::{env, sync::Arc};
 
+use graphql::schema::create_schema;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 
+use crate::graphql::schema::Context;
 use migration::{DbErr, Migrator, MigratorTrait};
+use warp::{filters::BoxedFilter, http::Response, Filter};
 
 pub mod auth;
 pub mod errors;
@@ -20,8 +23,44 @@ pub async fn connect_to_database(key: &str) -> Result<DatabaseConnection, DbErr>
     Ok(connection)
 }
 
+pub fn create_gql_filter(connection: DatabaseConnection) -> BoxedFilter<(Response<Vec<u8>>,)> {
+    let connection = Arc::new(connection);
+    let state = warp::any()
+        .and(warp::header::optional::<String>("Authorization"))
+        .map(move |auth: Option<String>| -> Context {
+            let token = get_token_from_header(auth);
+            Context {
+                connection: connection.clone(),
+                token,
+            }
+        });
+    juniper_warp::make_graphql_filter(create_schema(), state.boxed())
+}
+
 pub fn get_env(key: &str) -> String {
     env::var(key).unwrap_or_else(|_| panic!("{} environment variable is not defined", key))
+}
+
+pub fn get_token_from_header(header: Option<String>) -> String {
+    match header {
+        None => "".to_string(),
+        Some(header) => {
+            let mut split = header.split_whitespace();
+            match split.next() {
+                None => "".to_string(),
+                Some(bearer) => {
+                    if bearer != "Bearer" {
+                        return "".to_string();
+                    }
+                    let token = split.next();
+                    match token {
+                        None => "".to_string(),
+                        Some(val) => val.to_string(),
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -46,4 +85,18 @@ mod test {
         env::remove_var("TEST_VALUE");
         get_env("TEST_VALUE");
     }
+
+    #[test]
+    fn get_token_returns_empty_if_no_header() {}
+
+    #[test]
+    fn get_token_returns_empty_if_header_is_empty_string() {}
+    #[test]
+    fn get_token_returns_empty_if_first_word_not_bearer() {}
+
+    #[test]
+    fn get_token_returns_empty_if_no_token() {}
+
+    #[test]
+    fn get_token_returns_token_otherwise() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub fn get_token_from_header(header: Option<String>) -> String {
 mod test {
     use std::env;
 
-    use crate::get_env;
+    use crate::{get_env, get_token_from_header};
     #[test]
     fn get_env_success() {
         env::remove_var("TEST_VALUE");
@@ -87,16 +87,31 @@ mod test {
     }
 
     #[test]
-    fn get_token_returns_empty_if_no_header() {}
+    fn get_token_returns_empty_if_no_header() {
+        let res = get_token_from_header(None);
+        assert_eq!(res, "");
+    }
 
     #[test]
-    fn get_token_returns_empty_if_header_is_empty_string() {}
+    fn get_token_returns_empty_if_header_is_empty_string() {
+        let res = get_token_from_header(Some("".to_string()));
+        assert_eq!(res, "");
+    }
     #[test]
-    fn get_token_returns_empty_if_first_word_not_bearer() {}
+    fn get_token_returns_empty_if_first_word_not_bearer() {
+        let res = get_token_from_header(Some("Hello abcdef".to_string()));
+        assert_eq!(res, "");
+    }
 
     #[test]
-    fn get_token_returns_empty_if_no_token() {}
+    fn get_token_returns_empty_if_no_token() {
+        let res = get_token_from_header(Some("Bearer".to_string()));
+        assert_eq!(res, "");
+    }
 
     #[test]
-    fn get_token_returns_token_otherwise() {}
+    fn get_token_returns_token_otherwise() {
+        let res = get_token_from_header(Some("Bearer abcdef".to_string()));
+        assert_eq!(res, "abcdef");
+    }
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
-use sea_orm::{DatabaseBackend, DatabaseConnection, MockDatabase, ModelTrait};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use sea_orm::{prelude::Uuid, DatabaseBackend, DatabaseConnection, MockDatabase, ModelTrait};
 
-use crate::graphql::schema::Context;
+use crate::{auth::jwt::Claims, graphql::schema::Context};
+use entity::sea_orm_active_enums::Role;
 use migration::DbErr;
 
 #[allow(dead_code)]
@@ -33,4 +35,16 @@ pub fn create_errored_context(results: Vec<DbErr>, token: Option<String>) -> Con
     let token = token.unwrap_or_default();
     let connection = Arc::new(create_mock_errored_conn(results));
     Context { connection, token }
+}
+
+#[allow(dead_code)]
+pub fn create_test_jwt(id: &Uuid, role: &Role, time: u64) -> String {
+    let secret = "jwtsecret".as_bytes();
+    let claims = Claims {
+        sub: id.to_owned(),
+        role: role.to_str(),
+        exp: time,
+    };
+    let header = Header::new(Algorithm::HS512);
+    encode(&header, &claims, &EncodingKey::from_secret(secret)).unwrap()
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -48,3 +48,9 @@ pub fn create_test_jwt(id: &Uuid, role: &Role, time: u64) -> String {
     let header = Header::new(Algorithm::HS512);
     encode(&header, &claims, &EncodingKey::from_secret(secret)).unwrap()
 }
+
+#[allow(dead_code)]
+pub fn print_response_body(body: &Vec<u8>) {
+    let str = String::from_utf8(body.to_vec()).unwrap();
+    println!("{}", str);
+}

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use sea_orm::{prelude::Uuid, DatabaseBackend, DatabaseConnection, MockDatabase, ModelTrait};
 
-use crate::{auth::jwt::Claims, graphql::schema::Context};
+use crate::{auth::jwt::Claims, get_env, graphql::schema::Context};
 use entity::sea_orm_active_enums::Role;
 use migration::DbErr;
 
@@ -39,7 +39,8 @@ pub fn create_errored_context(results: Vec<DbErr>, token: Option<String>) -> Con
 
 #[allow(dead_code)]
 pub fn create_test_jwt(id: &Uuid, role: &Role, time: u64) -> String {
-    let secret = "jwtsecret".as_bytes();
+    let val = get_env("JWT_SECRET");
+    let secret = val.as_bytes();
     let claims = Claims {
         sub: id.to_owned(),
         role: role.to_str(),
@@ -50,7 +51,7 @@ pub fn create_test_jwt(id: &Uuid, role: &Role, time: u64) -> String {
 }
 
 #[allow(dead_code)]
-pub fn print_response_body(body: &Vec<u8>) {
+pub fn print_response_body(body: &[u8]) {
     let str = String::from_utf8(body.to_vec()).unwrap();
     println!("{}", str);
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,6 +2,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::errors::TimeError;
 
+pub const HOUR_IN_SECONDS: u16 = 3600;
+
 pub struct Time {}
 
 impl Time {
@@ -21,13 +23,15 @@ impl Time {
     }
 
     pub fn hour_hence() -> Result<Duration, TimeError> {
-        Self::now_plus_duration(Duration::from_secs(3600))
+        Self::now_plus_duration(Duration::from_secs(HOUR_IN_SECONDS.into()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use crate::time::HOUR_IN_SECONDS;
 
     use super::Time;
     #[test]
@@ -62,7 +66,7 @@ mod tests {
         let want = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .checked_add(Duration::from_secs(3600))
+            .checked_add(Duration::from_secs(HOUR_IN_SECONDS.into()))
             .unwrap();
         assert_eq!(got, want);
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -62,12 +62,15 @@ mod tests {
 
     #[test]
     fn now_plus_hour_correct() {
-        let got = Time::hour_hence().unwrap();
+        let got = Time::hour_hence().unwrap().as_secs();
         let want = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .checked_add(Duration::from_secs(HOUR_IN_SECONDS.into()))
-            .unwrap();
-        assert_eq!(got, want);
+            .unwrap()
+            .as_secs();
+
+        let difference = (got as i64) - (want as i64).abs();
+        assert!(difference < 5);
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -19,6 +19,10 @@ impl Time {
             None => Err(TimeError::CalculationError(duration.as_secs())),
         }
     }
+
+    pub fn hour_hence() -> Result<Duration, TimeError> {
+        Self::now_plus_duration(Duration::from_secs(3600))
+    }
 }
 
 #[cfg(test)]
@@ -49,6 +53,17 @@ mod tests {
         let got = Time::now_plus_duration(Duration::from_secs(60))
             .unwrap()
             .as_secs();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn now_plus_hour_correct() {
+        let got = Time::hour_hence().unwrap();
+        let want = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .checked_add(Duration::from_secs(3600))
+            .unwrap();
         assert_eq!(got, want);
     }
 }

--- a/tests/warp/user/mod.rs
+++ b/tests/warp/user/mod.rs
@@ -90,6 +90,7 @@ pub struct GQLSignupResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GQLAuthResponse {
     pub token: String,
+    pub user: GQLUserModel,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/warp/user/user_integration.rs
+++ b/tests/warp/user/user_integration.rs
@@ -58,6 +58,11 @@ mod integration_warp_user_integration {
         let data = response_json.data.unwrap();
         assert!(!data.signup.token.is_empty());
 
+        assert_eq!(data.signup.user.email, "test@test.com");
+        assert_eq!(data.signup.user.name, "test user");
+        assert_eq!(data.signup.user.role, "GUEST");
+        assert_eq!(data.signup.user.status, "ONLINE");
+
         let body: GQLRequest<()> = GQLRequest {
             query: r#"
                 mutation {
@@ -124,6 +129,11 @@ mod integration_warp_user_integration {
         let data = response_json.data.unwrap();
         assert!(!data.signup.token.is_empty());
 
+        assert_eq!(data.signup.user.email, "test2@test.com");
+        assert_eq!(data.signup.user.name, "test user2");
+        assert_eq!(data.signup.user.role, "GUEST");
+        assert_eq!(data.signup.user.status, "ONLINE");
+
         let body: GQLRequest<()> = GQLRequest {
             query: r#"
                 query {
@@ -179,9 +189,11 @@ mod integration_warp_user_integration {
 
         let token = create_test_jwt(
             &Uuid::from_str(&user2.id).unwrap(),
-            &Role::Admin,
+            &Role::Guest,
             Time::hour_hence().unwrap().as_secs(),
         );
+
+        println!("{}", token);
 
         let response = warp::test::request()
             .method("POST")
@@ -266,7 +278,14 @@ mod integration_warp_user_integration {
             query: r#"
                 mutation {
                     signin(email: "test2@test.com", password: "testpassword") {
-                        token  
+                        token
+                        user {
+                            id
+                            email
+                            name
+                            role
+                            status
+                        }
                     }
                 }
             "#
@@ -286,6 +305,11 @@ mod integration_warp_user_integration {
 
         let data = response_json.data.unwrap();
         assert!(!data.signin.token.is_empty());
+
+        assert_eq!(data.signin.user.email, "test2@test.com");
+        assert_eq!(data.signin.user.name, "test user2");
+        assert_eq!(data.signin.user.role, "GUEST");
+        assert_eq!(data.signin.user.status, "ONLINE");
 
         let body: GQLRequest<()> = GQLRequest {
             query: format!(

--- a/tests/warp/user/user_mutation.rs
+++ b/tests/warp/user/user_mutation.rs
@@ -2,6 +2,8 @@
 mod integration_warp_user_mutation {
     use dotenvy::dotenv;
     use entity::sea_orm_active_enums::{Role, Status};
+    use gilded_university_server::{testutils::create_test_jwt, time::Time};
+    use sea_orm::prelude::Uuid;
 
     use crate::{
         common::{delete_all_users, get_all_users, make_graphql_filter},
@@ -23,7 +25,14 @@ mod integration_warp_user_mutation {
             query: r#"
                 mutation {
                     signup(email: "test@test.com", name:"test user", password:"testpassword") {
-                        token  
+                        token
+                        user {
+                            id
+                            email
+                            name
+                            status
+                            role
+                        }
                     }
                 }
             "#
@@ -48,7 +57,14 @@ mod integration_warp_user_mutation {
             query: r#"
                 mutation {
                     signup(email: "test@test.com", name:"test user2", password:"testpassword") {
-                        token  
+                        token
+                        user {
+                            id
+                            email
+                            name
+                            role
+                            status
+                        }
                     }
                 }
             "#
@@ -83,7 +99,14 @@ mod integration_warp_user_mutation {
             query: r#"
                 mutation {
                     signout(email: "test@test.com") {
-                        success  
+                        success
+                        user {
+                            id
+                            email
+                            name
+                            role
+                            status
+                        }
                     }
                 }
             "#
@@ -92,6 +115,71 @@ mod integration_warp_user_mutation {
         };
         let response = warp::test::request()
             .method("POST")
+            .json(&body)
+            .filter(&filter)
+            .await
+            .unwrap();
+
+        let response_json: GQLSignoutRes = serde_json::from_slice(response.body()).unwrap();
+        assert!(response_json.errors.is_some());
+        assert!(response_json.data.is_none());
+
+        let errors = response_json.errors.unwrap();
+        assert_eq!(errors[0].message, "Unable to complete request");
+        assert_eq!(errors[0].path[0], "signout");
+
+        let body: GQLRequest<()> = GQLRequest {
+            query: r#"
+                mutation {
+                    signout(email: "test@test.com") {
+                        success  
+                    }
+                }
+            "#
+            .to_string(),
+            variables: None,
+        };
+        let token = create_test_jwt(
+            &Uuid::new_v4(),
+            &Role::Guest,
+            Time::hour_hence().unwrap().as_secs(),
+        );
+
+        let response = warp::test::request()
+            .method("POST")
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&body)
+            .filter(&filter)
+            .await
+            .unwrap();
+
+        let response_json: GQLSignoutRes = serde_json::from_slice(response.body()).unwrap();
+        assert!(response_json.errors.is_none());
+        assert!(response_json.data.is_some());
+
+        let errors = response_json.errors.unwrap();
+        assert_eq!(errors[0].message, "Unable to complete request");
+        assert_eq!(errors[0].path[0], "signout");
+
+        let body: GQLRequest<()> = GQLRequest {
+            query: r#"
+                mutation {
+                    signout(email: "test@test.com") {
+                        success
+                    }
+                }
+            "#
+            .to_string(),
+            variables: None,
+        };
+        let token = create_test_jwt(
+            &user1.id,
+            &Role::Guest,
+            Time::hour_hence().unwrap().as_secs(),
+        );
+        let response = warp::test::request()
+            .method("POST")
+            .header("Authorization", format!("Bearer {}", token))
             .json(&body)
             .filter(&filter)
             .await


### PR DESCRIPTION
* Upgrade Tokio to 1.23 for dependabot alert
* Add `HOUR_IN_SECONDS` constant to time to get rid of the magic numbers
* Add `get_claims_from_token` to lib to get the claims from the token.
* Remove the `Claims.expired` method because the jsonwebtoken does this automatically when decoding the token
* Add the user to signin and signup mutation responses (`AuthResponse`)
* Make a user unable to signing twice
* Modify the signout mutation to require that there is a token and that the token's sub is the same uuid as the user corresponding to the email given - cannot sign out another user
* Rename `UserResponse` to `GQLUser` and move it to a module in the `graphql` folder since it is shared. Also added the `::from_active_model` function that will take an active model and convert it into the graphql model.
* Fixed getting the authentication token from the authorization header. Also added the `get_token_from_header` library function so this can be tested
* Added a library function `create_gql_filter` which ensures that both tests and the main function are setting up the graphql filter in the same way
* Added tests for all of these

Closes GH-22